### PR TITLE
Fix bug in cxx:remove-package, does not remove the package.

### DIFF
--- a/src/clcxx.cpp
+++ b/src/clcxx.cpp
@@ -103,6 +103,8 @@ void PackageRegistry::remove_package(std::string lpack) {
   for (const auto &Func : pack.functions_meta_data()) {
     detail::remove_c_strings(Func);
   }
+  const auto iter = p_packages.find(lpack);
+  p_packages.erase(iter);
 }
 
 Package &PackageRegistry::create_package(std::string pack_name) {


### PR DESCRIPTION
In PackageRegistry::remove_package you need to explicitly remove the package, you can run it multiple times (cxx::remove-c-package "TEST") and it will return T.